### PR TITLE
Add support for opencv sharpening

### DIFF
--- a/opencv_test.go
+++ b/opencv_test.go
@@ -32,32 +32,31 @@ func dumpImage(filename string, data []byte) {
 }
 
 func imageTestHelper(t *testing.T, src_path string, output_prefix string, opts Options) {
-    assert := assert.New(t)
-    
-    // Read the input image and make sure there are no errors
-    f, err := os.Open(src_path)
+	assert := assert.New(t)
+
+	// Read the input image and make sure there are no errors
+	f, err := os.Open(src_path)
 	require.NoError(t, err)
 	src, err := ioutil.ReadAll(f)
 	require.NoError(t, err)
-    
-    // Perform the resize operation and make sure there are no errors
-    // Data will be jpeg encoded
+
+	// Perform the resize operation and make sure there are no errors
+	// Data will be jpeg encoded
 	data, err := Resize(src, opts)
-    
-    dest_name := fmt.Sprintf("%s%dx%d_%s", output_prefix, opts.Width, opts.Height, opts.Algo)
-    
-    // Write the resized image back to disk
-    dumpImage(dest_name, data)
-    
-    // Read back the resized image
+
+	dest_name := fmt.Sprintf("%s%dx%d_%s", output_prefix, opts.Width, opts.Height, opts.Algo)
+
+	// Write the resized image back to disk
+	dumpImage(dest_name, data)
+
+	// Read back the resized image
 	im, _, err := image.DecodeConfig(bytes.NewReader(data))
-    
-    // Make sure the resized image looks good
+
+	// Make sure the resized image looks good
 	assert.NoError(err)
 	assert.Equal(opts.Width, im.Width)
 	assert.Equal(opts.Height, im.Height)
 }
-
 
 func TestGeneric(t *testing.T) {
 	cleanup()
@@ -114,437 +113,455 @@ func TestGeneric(t *testing.T) {
 
 func Test100x100(t *testing.T) {
 
-    src_path := "testdata/100x100_square.png"
-    output_prefix := "100x100_square_to_"
-    
-    opts := Options{
-         Algo: FILL,
-         Gravity: WEST,
-         Width: 50, 
-         Height: 50,
+	src_path := "testdata/100x100_square.png"
+	output_prefix := "100x100_square_to_"
+
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  50,
 	}
-    
-    imageTestHelper(t, src_path, output_prefix, opts)
+
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a tall portion at the center of the image
 func Test100x200TallCenter(t *testing.T) {
 
-    src_path := "testdata/100x200_tall_center.png"
-    output_prefix := "100x200_tall_center_to_"
+	src_path := "testdata/100x200_tall_center.png"
+	output_prefix := "100x200_tall_center_to_"
 
-    // Just a crop, take the center
-    opts := Options{
-         Algo: FILL,
-         Gravity: CENTER,
-         Width: 50, 
-         Height: 200,
+	// Just a crop, take the center
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   50,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the center
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH,
-         Width: 25, 
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   25,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the center
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH,
-         Width: 100,
-         Height: 400,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  400,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a tall portion at the left of the image
 func Test100x200TallLeft(t *testing.T) {
 
-    src_path := "testdata/100x200_tall_left.png"
-    output_prefix := "100x200_tall_left_to_"
-    
-    // Just a crop, take the left
-    opts := Options{
-         Algo: FILL,
-         Gravity: WEST,
-         Width: 50, 
-         Height: 200,
+	src_path := "testdata/100x200_tall_left.png"
+	output_prefix := "100x200_tall_left_to_"
+
+	// Just a crop, take the left
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the left
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_WEST,
-         Width: 25, 
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   25,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the left
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_WEST,
-         Width: 100,
-         Height: 400,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   100,
+		Height:  400,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a tall portion at the right of the image
 func Test100x200TallRight(t *testing.T) {
 
-    src_path := "testdata/100x200_tall_right.png"
-    output_prefix := "100x200_tall_right_to_"
-    
-    // Just a crop, take the right
-    opts := Options{
-         Algo: FILL,
-         Gravity: EAST,
-         Width: 50, 
-         Height: 200,
+	src_path := "testdata/100x200_tall_right.png"
+	output_prefix := "100x200_tall_right_to_"
+
+	// Just a crop, take the right
+	opts := Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the right
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_EAST,
-         Width: 25, 
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   25,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the right
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_EAST,
-         Width: 100,
-         Height: 400,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  400,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the bottom of the image
 func Test100x200WideBottom(t *testing.T) {
 
-    src_path := "testdata/100x200_wide_bottom.png"
-    output_prefix := "100x200_wide_bottom_to_"
-    
-    // Just a crop, take the bottom
-    opts := Options{
-         Algo: FILL,
-         Gravity: SOUTH,
-         Width: 100, 
-         Height: 50,
+	src_path := "testdata/100x200_wide_bottom.png"
+	output_prefix := "100x200_wide_bottom_to_"
+
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_EAST,
-         Width: 50, 
-         Height: 25,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   50,
+		Height:  25,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_WEST,
-         Width: 200,
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   200,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the bottom of the image
 func Test100x200WideCenter(t *testing.T) {
 
-    src_path := "testdata/100x200_wide_center.png"
-    output_prefix := "100x200_wide_center_to_"
-    
-    // Just a crop, take the bottom
-    opts := Options{
-         Algo: FILL,
-         Gravity: CENTER,
-         Width: 100, 
-         Height: 50,
+	src_path := "testdata/100x200_wide_center.png"
+	output_prefix := "100x200_wide_center_to_"
+
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   100,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: EAST,
-         Width: 50, 
-         Height: 25,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  25,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: WEST,
-         Width: 200,
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   200,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the top of the image
 func Test100x200WideTop(t *testing.T) {
 
-    src_path := "testdata/100x200_wide_top.png"
-    output_prefix := "100x200_wide_top_to_"
-    
-    // Just a crop, take the top
-    opts := Options{
-         Algo: FILL,
-         Gravity: NORTH,
-         Width: 100, 
-         Height: 50,
+	src_path := "testdata/100x200_wide_top.png"
+	output_prefix := "100x200_wide_top_to_"
+
+	// Just a crop, take the top
+	opts := Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   100,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the top
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_EAST,
-         Width: 50, 
-         Height: 25,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   50,
+		Height:  25,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the top
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_WEST,
-         Width: 200,
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   200,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
-
 
 // Here we have a wide source image and we are always cropping a tall portion at the center of the image
 func Test200x100TallCenter(t *testing.T) {
 
-    src_path := "testdata/200x100_tall_center.png"
-    output_prefix := "200x100_tall_center_to_"
+	src_path := "testdata/200x100_tall_center.png"
+	output_prefix := "200x100_tall_center_to_"
 
-    // Just a crop, take the center
-    opts := Options{
-         Algo: FILL,
-         Gravity: CENTER,
-         Width: 50, 
-         Height: 100,
+	// Just a crop, take the center
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   50,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the center
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH,
-         Width: 25, 
-         Height: 50,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   25,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the center
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH,
-         Width: 100,
-         Height: 200,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a tall portion at the left of the image
 func Test200x100TallLeft(t *testing.T) {
 
-    src_path := "testdata/200x100_tall_left.png"
-    output_prefix := "200x100_tall_left_to_"
-    
-    // Just a crop, take the left
-    opts := Options{
-         Algo: FILL,
-         Gravity: WEST,
-         Width: 50, 
-         Height: 100,
+	src_path := "testdata/200x100_tall_left.png"
+	output_prefix := "200x100_tall_left_to_"
+
+	// Just a crop, take the left
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the left
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_WEST,
-         Width: 25, 
-         Height: 50,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   25,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the left
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_WEST,
-         Width: 100,
-         Height: 200,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   100,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a tall portion at the right of the image
 func Test200x100TallRight(t *testing.T) {
 
-    src_path := "testdata/200x100_tall_right.png"
-    output_prefix := "200x100_tall_right_to_"
-    
-    // Just a crop, take the right
-    opts := Options{
-         Algo: FILL,
-         Gravity: EAST,
-         Width: 50, 
-         Height: 100,
+	src_path := "testdata/200x100_tall_right.png"
+	output_prefix := "200x100_tall_right_to_"
+
+	// Just a crop, take the right
+	opts := Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the right
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_EAST,
-         Width: 25, 
-         Height: 50,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   25,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the right
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_EAST,
-         Width: 100,
-         Height: 200,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  200,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the bottom of the image
 func Test200x100WideBottom(t *testing.T) {
 
-    src_path := "testdata/200x100_wide_bottom.png"
-    output_prefix := "200x100_wide_bottom_to_"
-    
-    // Just a crop, take the bottom
-    opts := Options{
-         Algo: FILL,
-         Gravity: SOUTH,
-         Width: 200, 
-         Height: 50,
+	src_path := "testdata/200x100_wide_bottom.png"
+	output_prefix := "200x100_wide_bottom_to_"
+
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   200,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_EAST,
-         Width: 100, 
-         Height: 25,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  25,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: SOUTH_WEST,
-         Width: 400,
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   400,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the bottom of the image
 func Test200x100WideCenter(t *testing.T) {
 
-    src_path := "testdata/200x100_wide_center.png"
-    output_prefix := "200x100_wide_center_to_"
-    
-    // Just a crop, take the bottom
-    opts := Options{
-         Algo: FILL,
-         Gravity: CENTER,
-         Width: 200, 
-         Height: 50,
+	src_path := "testdata/200x100_wide_center.png"
+	output_prefix := "200x100_wide_center_to_"
+
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   200,
+		Height:  50,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: EAST,
-         Width: 100, 
-         Height: 25,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   100,
+		Height:  25,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the bottom
-    opts = Options{
-         Algo: FILL,
-         Gravity: WEST,
-         Width: 400,
-         Height: 100,
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   400,
+		Height:  100,
 	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	imageTestHelper(t, src_path, output_prefix, opts)
 
 }
 
 // Here we have a tall source image and we are always cropping a wide portion at the top of the image
 func Test200x100WideTop(t *testing.T) {
 
-    src_path := "testdata/200x100_wide_top.png"
-    output_prefix := "200x100_wide_top_to_"
-    
-    // Just a crop, take the top
-    opts := Options{
-         Algo: FILL,
-         Gravity: NORTH,
-         Width: 200, 
-         Height: 50,
-	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Shrink, take the top
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_EAST,
-         Width: 100, 
-         Height: 25,
-	}
-    imageTestHelper(t, src_path, output_prefix, opts)
-    
-    // Enlarge, take the top
-    opts = Options{
-         Algo: FILL,
-         Gravity: NORTH_WEST,
-         Width: 400,
-         Height: 100,
-	}
-    imageTestHelper(t, src_path, output_prefix, opts)
+	src_path := "testdata/200x100_wide_top.png"
+	output_prefix := "200x100_wide_top_to_"
 
+	// Just a crop, take the top
+	opts := Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   200,
+		Height:  50,
+	}
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Shrink, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   100,
+		Height:  25,
+	}
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+	// Enlarge, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   400,
+		Height:  100,
+	}
+	imageTestHelper(t, src_path, output_prefix, opts)
+
+}
+
+func TestResizeFromFile(t *testing.T) {
+	opts := Options{
+		Algo:          FILL,
+		Gravity:       NORTH_WEST,
+		Width:         300,
+		Height:        200,
+		SharpenAmount: 100,
+		SharpenRadius: 0.5,
+	}
+
+	srcPath := "testdata/200x100_wide_top.png"
+
+	_, err := ResizeFromFile(srcPath, opts)
+	assert.NoError(t, err)
+
+	_, err = ResizeFromFile("NotAFile", opts)
+	assert.Error(t, err)
 }

--- a/options.go
+++ b/options.go
@@ -22,13 +22,15 @@ const (
 )
 
 type Options struct {
-	Width      int
-	Height     int
-	Algo       Algo
-	Background [3]int
-	Gravity    Gravity
-	Enalarge   bool
-	Quality    int
+	Width         int
+	Height        int
+	Algo          Algo
+	Background    [3]int
+	Gravity       Gravity
+	Enalarge      bool
+	Quality       int
+	SharpenRadius float64
+	SharpenAmount int
 }
 
 func (a Algo) String() string {

--- a/sharpen.cpp
+++ b/sharpen.cpp
@@ -1,0 +1,16 @@
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+extern "C" {
+IplImage sharpen(IplImage* img, int sharpenAmount, double radius) {
+    // Convert IplImage* -> Mat
+    cv::Mat raw(img);
+    
+    // Now, sharpen the Mat.
+    cv::Mat sharpened;
+    GaussianBlur(raw, sharpened, cv::Size(0, 0), radius);
+    addWeighted(raw, 1.0 + (sharpenAmount/100.0), sharpened, -(sharpenAmount/100.0), 0, sharpened);
+    return static_cast<IplImage>(sharpened);
+}
+} // extern "C"

--- a/sharpen.h
+++ b/sharpen.h
@@ -1,0 +1,11 @@
+#ifndef CPPLIB_H
+    #define CPPLIB_H
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
+    #include <opencv/cv.h>
+    IplImage sharpen(IplImage* img, int sharpenAmount, double radius);
+    #ifdef __cplusplus
+    }
+    #endif
+#endif


### PR DESCRIPTION
So basically now, there is an option to do EVERYTHING we need to do in t-rez without stepping out of it for decoding, encoding, or sharpening.

@filitchp Can you take a look? Not totally sure what dependencies have to be added to one's system to get all this to work, but this works and adds sharpening!

Once's I figure out the deps, I'll update the README
